### PR TITLE
Use Autoconf to check for strlcpy

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,5 +1,8 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define to 1 if you have the <bsd/string.h> header file. */
+#undef HAVE_BSD_STRING_H
+
 /* Define to 1 if you have the <fcntl.h> header file. */
 #undef HAVE_FCNTL_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,11 @@ AC_TYPE_SSIZE_T
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([memmove setlocale strdup])
+AC_SEARCH_LIBS([strlcpy], [bsd], [], [
+  AC_MSG_ERROR([unable to find strlcpy() function])
+])
+
+AC_CHECK_HEADERS([bsd/string.h])
 
 # sys/queue.h exists on most systems, but its capabilities vary a great deal.
 # Test for required macros.

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([memmove setlocale strdup])
 AC_SEARCH_LIBS([strlcpy], [bsd], [], [
-  AC_MSG_ERROR([unable to find strlcpy() function])
+  AC_MSG_ERROR([unable to find strlcpy() function. Try to install libbsd])
 ])
 AC_SEARCH_LIBS([initscr], [ncurses], [], [
   AC_MSG_ERROR([unable to find initscr() function. Try to install ncurses])

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,9 @@ AC_CHECK_FUNCS([memmove setlocale strdup])
 AC_SEARCH_LIBS([strlcpy], [bsd], [], [
   AC_MSG_ERROR([unable to find strlcpy() function])
 ])
+AC_SEARCH_LIBS([initscr], [ncurses], [], [
+  AC_MSG_ERROR([unable to find initscr() function. Try to install ncurses])
+])
 
 AC_CHECK_HEADERS([bsd/string.h])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_LDFLAGS=-lncurses -lbsd
+AM_LDFLAGS=-lncurses
 AM_CFLAGS=-Wall -Wextra -pedantic-errors -Wno-unused-parameter -Werror
 bin_PROGRAMS=pick
 dist_pick_SOURCES=choice.c choice.h choices.c choices.h io.c io.h main.c ui.c ui.h compat/queue.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,3 @@
-AM_LDFLAGS=-lncurses
 AM_CFLAGS=-Wall -Wextra -pedantic-errors -Wno-unused-parameter -Werror
 bin_PROGRAMS=pick
 dist_pick_SOURCES=choice.c choice.h choices.c choices.h io.c io.h main.c ui.c ui.h compat/queue.h

--- a/src/ui.c
+++ b/src/ui.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <assert.h>
 
 #ifdef HAVE_BSD_STRING_H
 #include <bsd/string.h>
@@ -49,7 +50,7 @@ start_curses()
 	int fd;
 
 	signal(SIGINT, int_handler);
-	freopen("/dev/tty", "r", stdin);
+	assert(freopen("/dev/tty", "r", stdin));
 	setlocale(LC_ALL, "");
 	fflush(stdout);
 	stdoutfd = dup(STDOUT_FILENO);

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include <curses.h>
 #include <err.h>
 #include <fcntl.h>
@@ -7,7 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+#ifdef HAVE_BSD_STRING_H
 #include <bsd/string.h>
+#endif
 
 #ifdef HAVE_FULL_QUEUE_H
 #include <sys/queue.h>

--- a/src/ui.c
+++ b/src/ui.c
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <assert.h>
 
 #ifdef HAVE_BSD_STRING_H
 #include <bsd/string.h>
@@ -50,7 +49,8 @@ start_curses()
 	int fd;
 
 	signal(SIGINT, int_handler);
-	assert(freopen("/dev/tty", "r", stdin));
+	if (freopen("/dev/tty", "r", stdin) == NULL)
+		err(1, "freopen");
 	setlocale(LC_ALL, "");
 	fflush(stdout);
 	stdoutfd = dup(STDOUT_FILENO);


### PR DESCRIPTION
Autoconf can check for strlcpy. If it finds it without having to use
a library it won't add anything to LIBS. Otherwise it will try
libbsd and if finds it there it will link libbsd.

Use also AC_CHECK_HEADERS to only include bsd/string.h if it actually
exists.