### PR TITLE
Underline portion of matches

### DIFF
--- a/src/choice.h
+++ b/src/choice.h
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #ifndef CHOICE_H
 #define CHOICE_H
 
@@ -11,6 +12,8 @@ struct choice {
     char *str;
     char *desc;
     float score;
+    size_t start_pos;
+    size_t match_len;
     SLIST_ENTRY(choice) choices;          /* List. */
 };
 

--- a/src/choice.h
+++ b/src/choice.h
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #ifndef CHOICE_H
 #define CHOICE_H
 
@@ -12,8 +11,8 @@ struct choice {
     char *str;
     char *desc;
     float score;
-    size_t start_pos;
-    size_t match_len;
+    int mpos;
+    int mlen;
     SLIST_ENTRY(choice) choices;          /* List. */
 };
 

--- a/src/choices.c
+++ b/src/choices.c
@@ -14,7 +14,7 @@
 #include "choices.h"
 
 size_t
-min_match_length(char *str, char *query, size_t *match_start_po)
+min_match_length(char *str, char *query, size_t *start_pos)
 {
 	size_t mlen;
 	size_t mstart;
@@ -22,31 +22,27 @@ min_match_length(char *str, char *query, size_t *match_start_po)
 	size_t mpos;
 	int matched = 0;
 
-	for (mlen = 0, mstart = 0; str[mstart] != '\0'; ++mstart) {
+	for (mlen = 0, mstart = 0; str[mstart] != '\0'; ++mstart)
 		if (tolower(str[mstart]) == tolower(query[0])) {
 			if (matched == 0) {
 				matched = 1;
-				*match_start_po = mstart;
+				*start_pos = mstart;
 			}
 
-			for (qpos = 1, mpos = mstart + 1; query[qpos] != '\0'; ++qpos) {
+			for (qpos = 1, mpos = mstart + 1; query[qpos] != '\0'; ++qpos)
 				for (;; ++mpos) {
-					if (str[mpos] == '\0') {
-						return mlen;
-					}
+					if (str[mpos] == '\0')
+            return mlen;
 
 					if (tolower(str[mpos]) == tolower(query[qpos])) {
 						++mpos;
 						break;
 					}
 				}
-			}
 
-			if (mlen == 0 || mlen > mpos - mstart + 1) {
-				mlen = mpos - mstart + 1;
-			}
+			if (mlen == 0 || mlen > mpos - mstart + 1)
+        mlen = mpos - mstart + 1;
 		}
-	}
 
 	return mlen;
 }

--- a/src/choices.c
+++ b/src/choices.c
@@ -32,7 +32,7 @@ min_match_length(char *str, char *query, size_t *start_pos)
 			for (qpos = 1, mpos = mstart + 1; query[qpos] != '\0'; ++qpos)
 				for (;; ++mpos) {
 					if (str[mpos] == '\0')
-            return mlen;
+						return mlen;
 
 					if (tolower(str[mpos]) == tolower(query[qpos])) {
 						++mpos;
@@ -41,7 +41,7 @@ min_match_length(char *str, char *query, size_t *start_pos)
 				}
 
 			if (mlen == 0 || mlen > mpos - mstart + 1)
-        mlen = mpos - mstart + 1;
+				mlen = mpos - mstart + 1;
 		}
 
 	return mlen;

--- a/src/choices.c
+++ b/src/choices.c
@@ -33,17 +33,14 @@ min_match_length(char *str, char *query, size_t *start_pos)
 				for (;; ++mpos) {
 					if (str[mpos] == '\0')
 						return mlen;
-
 					if (tolower(str[mpos]) == tolower(query[qpos])) {
 						++mpos;
 						break;
 					}
 				}
-
 			if (mlen == 0 || mlen > mpos - mstart + 1)
 				mlen = mpos - mstart + 1;
 		}
-
 	return mlen;
 }
 

--- a/src/choices.c
+++ b/src/choices.c
@@ -14,20 +14,17 @@
 #include "choices.h"
 
 size_t
-min_match_length(char *str, char *query, size_t *start_pos)
+min_match_length(char *str, char *query, int *start_pos)
 {
 	size_t mlen;
 	size_t mstart;
 	size_t qpos;
 	size_t mpos;
-	int matched = 0;
 
 	for (mlen = 0, mstart = 0; str[mstart] != '\0'; ++mstart)
 		if (tolower(str[mstart]) == tolower(query[0])) {
-			if (matched == 0) {
-				matched = 1;
+			if (*start_pos == -1)
 				*start_pos = mstart;
-			}
 
 			for (qpos = 1, mpos = mstart + 1; query[qpos] != '\0'; ++qpos)
 				for (;; ++mpos) {
@@ -45,7 +42,7 @@ min_match_length(char *str, char *query, size_t *start_pos)
 }
 
 float
-score_str(char *str, char *query, size_t *mpos, size_t *mlen)
+score_str(char *str, char *query, int *mpos, size_t *mlen)
 {
 	size_t slen;
 	size_t qlen;
@@ -65,7 +62,7 @@ void
 choices_score(struct choices *cs, char *query)
 {
 	struct choice *c;
-	size_t mpos = 0;
+	int mpos = 0;
 	size_t mlen = 0;
 
 	SLIST_FOREACH(c, cs, choices) {

--- a/src/choices.c
+++ b/src/choices.c
@@ -14,32 +14,51 @@
 #include "choices.h"
 
 size_t
-min_match_length(char *str, char *query)
+min_match_length(char *candidate, char *query, size_t *match_start_po)
 {
-	size_t mlen;
-	size_t mstart;
-	size_t qpos;
-	size_t mpos;
+	size_t min_match_len;
+	size_t match_start_pos;
+	size_t query_pos;
+	size_t match_pos;
 
-	for (mlen = 0, mstart = 0; str[mstart] != '\0'; ++mstart)
-		if (tolower(str[mstart]) == tolower(query[0])) {
-			for (qpos = 1, mpos = mstart + 1; query[qpos] != '\0'; ++qpos)
-				for (;; ++mpos) {
-					if (str[mpos] == '\0')
-						return mlen;
-					if (tolower(str[mpos]) == tolower(query[qpos])) {
-						++mpos;
-						break;
+  int matched = 0;
+
+  // loop over query candidateing
+	for (min_match_len = 0, match_start_pos = 0; candidate[match_start_pos] != '\0'; ++match_start_pos) {
+    // check if there's a match with the first query character
+		if (tolower(candidate[match_start_pos]) == tolower(query[0])) {
+      if (matched == 0) {
+        matched = 1;
+        *match_start_po = match_start_pos;
+      }
+      // loop over remaining characters in the query candidateing
+			for (query_pos = 1, match_pos = match_start_pos + 1; query[query_pos] != '\0'; ++query_pos) {
+
+        // see if there's a matching character in
+        // the remaining characters of the filename
+				for (;; ++match_pos) {
+					if (candidate[match_pos] == '\0') {
+						return min_match_len;
+          }
+
+					if (tolower(candidate[match_pos]) == tolower(query[query_pos])) {
+						++match_pos;
+						break; // move on to next query character
 					}
 				}
-			if (mlen == 0 || mlen > mpos - mstart + 1)
-				mlen = mpos - mstart + 1;
+      }
+
+      size_t curr_match_len = match_pos - match_start_pos + 1;
+			if (min_match_len == 0 || min_match_len > curr_match_len)
+				min_match_len = curr_match_len;
 		}
-	return mlen;
+  }
+
+	return min_match_len;
 }
 
 float
-score_str(char *str, char *query)
+score_str(char *str, char *query, size_t *start_pos, size_t *match_len)
 {
 	size_t slen;
 	size_t qlen;
@@ -48,11 +67,12 @@ score_str(char *str, char *query)
 	slen = strlen(str);
 	qlen = strlen(query);
 	if (qlen == 0)
-		return 1;	
+		return 1;
 	if (slen == 0)
 		return 0;
-	if ((mlen = min_match_length(str, query)) == 0)
+	if ((mlen = min_match_length(str, query, start_pos)) == 0)
 		return 0;
+  *match_len = mlen;
 	return (float)qlen / (float)mlen / (float)slen;
 }
 
@@ -61,9 +81,13 @@ void
 choices_score(struct choices *cs, char *query)
 {
 	struct choice *c;
+  size_t start_pos = 0;
+  size_t match_len = 0;
 
 	SLIST_FOREACH(c, cs, choices) {
-		c->score = score_str(c->str, query);
+		c->score = score_str(c->str, query, &start_pos, &match_len);
+    c->start_pos = start_pos;
+    c->match_len = match_len;
 	}
 }
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -84,7 +84,7 @@ int_handler()
 	exit(EX_SIGINT);
 }
 
-	void
+void
 put_line(int y, char *str, int len, int so, int mpos, int mlen)
 {
 	if (so)
@@ -143,8 +143,8 @@ put_choices(struct choices *cs, int sel)
 		    line,
 		    len,
 		    vis_choices == sel,
-				c->mpos,
-				c->mlen);
+		    c->mpos,
+		    c->mlen);
 		++vis_choices;
 	}
 	free(line);

--- a/src/ui.c
+++ b/src/ui.c
@@ -92,11 +92,13 @@ put_line(int y, char *str, int len, int so, int start_pos, int match_len)
 
   if (len > 0) {
     for (int i = 0; str[i] != '\0'; i++) {
-      if(i == start_pos)
+      if (i == start_pos) {
         attron(A_UNDERLINE);
+      }
 
-      if(i >= start_pos + match_len - 1)
+      if (i >= start_pos + match_len - 1) {
         attroff(A_UNDERLINE);
+      }
 
       mvaddch(y, i, str[i]);
     }
@@ -144,8 +146,8 @@ put_choices(struct choices *cs, int sel)
 		    line,
 		    len,
 		    vis_choices == sel,
-        c->start_pos,
-        c->match_len);
+        c->mpos,
+        c->mlen);
 		++vis_choices;
 	}
 	free(line);

--- a/src/ui.c
+++ b/src/ui.c
@@ -89,7 +89,6 @@ put_line(int y, char *str, int len, int so, int mpos, int mlen)
 {
 	if (so)
 		standout();
-
 	if (len > 0)
 		for (int i = 0; str[i] != '\0'; i++) {
 			if (i == mpos)
@@ -100,7 +99,6 @@ put_line(int y, char *str, int len, int so, int mpos, int mlen)
 
 			mvaddch(y, i, str[i]);
 		}
-
 	move(y, len);
 	for (; len < COLS; ++len)
 		addch(' ');

--- a/src/ui.c
+++ b/src/ui.c
@@ -90,7 +90,7 @@ put_line(int y, char *str, int len, int so, int mpos, int mlen)
 	if (so)
 		standout();
 
-	if (len > 0) {
+	if (len > 0)
 		for (int i = 0; str[i] != '\0'; i++) {
 			if (i == mpos)
 				attron(A_UNDERLINE);
@@ -100,7 +100,6 @@ put_line(int y, char *str, int len, int so, int mpos, int mlen)
 
 			mvaddch(y, i, str[i]);
 		}
-	}
 
 	move(y, len);
 	for (; len < COLS; ++len)

--- a/src/ui.c
+++ b/src/ui.c
@@ -84,32 +84,29 @@ int_handler()
 	exit(EX_SIGINT);
 }
 
-void
-put_line(int y, char *str, int len, int so, int start_pos, int match_len)
+	void
+put_line(int y, char *str, int len, int so, int mpos, int mlen)
 {
-  if (so)
-    standout();
+	if (so)
+		standout();
 
-  if (len > 0) {
-    for (int i = 0; str[i] != '\0'; i++) {
-      if (i == start_pos) {
-        attron(A_UNDERLINE);
-      }
+	if (len > 0) {
+		for (int i = 0; str[i] != '\0'; i++) {
+			if (i == mpos)
+				attron(A_UNDERLINE);
 
-      if (i >= start_pos + match_len - 1) {
-        attroff(A_UNDERLINE);
-      }
+			if (i >= mpos + mlen - 1)
+				attroff(A_UNDERLINE);
 
-      mvaddch(y, i, str[i]);
-    }
-  }
+			mvaddch(y, i, str[i]);
+		}
+	}
 
-  move(y, len);
-
-  for (; len < COLS; ++len)
-    addch(' ');
-  if (so)
-    standend();
+	move(y, len);
+	for (; len < COLS; ++len)
+		addch(' ');
+	if (so)
+		standend();
 }
 
 int
@@ -146,8 +143,8 @@ put_choices(struct choices *cs, int sel)
 		    line,
 		    len,
 		    vis_choices == sel,
-        c->mpos,
-        c->mlen);
+				c->mpos,
+				c->mlen);
 		++vis_choices;
 	}
 	free(line);

--- a/src/ui.c
+++ b/src/ui.c
@@ -85,17 +85,29 @@ int_handler()
 }
 
 void
-put_line(int y, char *str, int len, int so)
+put_line(int y, char *str, int len, int so, int start_pos, int match_len)
 {
-	if (so)
-		standout();
-	if (len > 0)
-		mvaddstr(y, 0, str);
-	move(y, len);
-	for (; len < COLS; ++len)
-		addch(' ');
-	if (so)
-		standend();
+  if (so)
+    standout();
+
+  if (len > 0) {
+    for (int i = 0; str[i] != '\0'; i++) {
+      if(i == start_pos)
+        attron(A_UNDERLINE);
+
+      if(i >= start_pos + match_len - 1)
+        attroff(A_UNDERLINE);
+
+      mvaddch(y, i, str[i]);
+    }
+  }
+
+  move(y, len);
+
+  for (; len < COLS; ++len)
+    addch(' ');
+  if (so)
+    standend();
 }
 
 int
@@ -131,12 +143,14 @@ put_choices(struct choices *cs, int sel)
 		    vis_choices + 1,
 		    line,
 		    len,
-		    vis_choices == sel);
+		    vis_choices == sel,
+        c->start_pos,
+        c->match_len);
 		++vis_choices;
 	}
 	free(line);
 	for (i = vis_choices + 1; i < LINES; ++i)
-		put_line(i, "", 0, 0);
+		put_line(i, "", 0, 0, 0, 0);
 
 	return vis_choices;
 }
@@ -201,7 +215,7 @@ get_selected(struct choices *cs, char *initial_query)
 	filter_choices(cs, query, &sel);
 	start_curses();
 
-	put_line(0, query, query_len, 0);
+	put_line(0, query, query_len, 0, 0, 0);
 	vis_choices = put_choices(cs, sel);
 	move(0, cursor_pos);
 	refresh();
@@ -321,7 +335,7 @@ get_selected(struct choices *cs, char *initial_query)
 					    query_size * sizeof(char))) == NULL)
 				err(1, "realloc");
 		}
-		put_line(0, query, query_len, 0);
+		put_line(0, query, query_len, 0, 0, 0);
 		vis_choices = put_choices(cs, sel);
 		move(0, cursor_pos);
 		refresh();


### PR DESCRIPTION
![screen shot 2015-01-23 at 20 17 47](https://cloud.githubusercontent.com/assets/283886/5886083/fc255928-a33c-11e4-8c8a-2115133c310c.png)

This implements underlining the portion of matches that make them order it. I'd love some other people to look over and try this to catch the edge cases. As you can see in the screenshot there is an off by one error somewhere so the bottom match isn't underlined correctly. We may also prefer some other color changes here but whatever everyone wants to do is fine.