### PR TITLE
Solve Vim `system()` related issues.

### DIFF
--- a/man/man1/pick.1
+++ b/man/man1/pick.1
@@ -10,6 +10,7 @@
 .Op Fl v
 .Op Fl q Ar QUERY
 .Op Fl d Op Fl o
+.Op Fl X
 .Sh DESCRIPTION
 .Nm pick
 allows users to select from a set of choices using an
@@ -40,6 +41,13 @@ Both parts will be displayed but only the first part will be used when
 searching.
 .It Fl o
 output description of selected on exit.
+.It Fl X
+disable the use of the alternate screen terminal feature. This is required when running
+.Nm pick
+using
+.Fn system
+from within
+.Xr vim 1 .
 .El
 .Pp
 The

--- a/src/main.c
+++ b/src/main.c
@@ -17,13 +17,15 @@ main(int argc,char **argv)
 	int ch;
 	int display_desc;
 	int output_desc;
+	int use_alternate_screen;
 	char *query;
 	struct choices *cs;
 
 	display_desc = 0;
 	output_desc = 0;
+	use_alternate_screen = 1;
 	query = "";
-	while ((ch = getopt(argc, argv, "hvdoq:")) != -1)
+	while ((ch = getopt(argc, argv, "hvdoq:X")) != -1)
 		switch (ch) {
 		case 'v':
 			version();
@@ -36,6 +38,9 @@ main(int argc,char **argv)
 		case 'q':
 			query = optarg;
 			break;
+		case 'X':
+			use_alternate_screen = 0;
+			break;
 		default:
 			usage();
 		}
@@ -45,7 +50,7 @@ main(int argc,char **argv)
 	output_desc = output_desc && display_desc;
 
 	cs = get_choices(display_desc);
-	put_choice(get_selected(cs, query), output_desc);
+	put_choice(get_selected(cs, query, use_alternate_screen), output_desc);
 	choices_free(cs);
 	return EX_OK;
 }

--- a/src/ui.h
+++ b/src/ui.h
@@ -4,6 +4,6 @@
 #include "choice.h"
 #include "choices.h"
 
-struct choice    *get_selected(struct choices *, char *);
+struct choice    *get_selected(struct choices *, char *, int);
 
 #endif /* UI_H */


### PR DESCRIPTION
- Replace ncurses with tputs and termios.
- Add an `-X` option to disable use of the alternate screen.

Hopefully solves #4, #18, #19 and #20.

@Keithbsmiley, @mike-burns, @teoljungberg  and @ggilder, could you guys help test this on your machines?