### PR TITLE
Remove experimental notice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@ pick(1)
 `pick(1)` allows users to choose one from set of choices using an
 `ncurses(3X)` interface with fuzzy search functionality.
 
-**Please note**: `pick(1)` is **experimental software**. It has some
-[issues](https://github.com/thoughtbot/pick/issues). If you'd like to help
-resolving them please see the instructions in
-[`CONTRIBUTING.md`](https://github.com/thoughtbot/pick/blob/master/CONTRIBUTING.md).
-Pull requests are very welcome.
-
 Installation
 ------------
 


### PR DESCRIPTION
After fixing the issues related to Vim `system()` I feel confident removing
the notice about pick being experimental software.