### PR TITLE
Use the sha of the actual release tarball.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,5 +55,7 @@ release_push_arch:
 release_clean_arch:
 	rm -rf release-arch
 
-DIST_SHA: Makefile distcheck
+DIST_SHA: Makefile
+	rm $(srcdir)/$(DIST_ARCHIVES)
+	wget "https://github.com/thoughtbot/$(PACKAGE)/releases/download/v$(PACKAGE_VERSION)/$(DIST_ARCHIVES)" -O $(srcdir)/$(DIST_ARCHIVES)
 	$(eval DIST_SHA := $(shell shasum $(srcdir)/$(DIST_ARCHIVES) | cut -d' ' -f1))


### PR DESCRIPTION
The sha of the tarball generated by `make distcheck` is different on every
run because of the file modification time of files in the archive.

Downloading the actual release tarball and using the sha for that in the
Homebrew formula and AUR PKGBUILD ensures that they contain the correct sha.