### PR TITLE
Open `/dev/tty/` in read and append mode. 

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -72,7 +72,6 @@ start_ui()
 	tcgetattr(fileno(tty), &oldattr);
 	newattr = oldattr;
 	newattr.c_lflag &= ~(ICANON | ECHO);
-	newattr.c_lflag &= ~(ICANON | ECHO);
 	tcsetattr(fileno(tty), TCSANOW, &newattr);
 	setupterm((char *)0, fileno(tty), (int *)0);
 	if (using_alternate_screen) {

--- a/src/ui.c
+++ b/src/ui.c
@@ -66,7 +66,7 @@ void
 start_ui()
 {
 	struct termios newattr;
-	if ((tty = fopen("/dev/tty", "w+")) == NULL) {
+	if ((tty = fopen("/dev/tty", "a+")) == NULL) {
 		err(1, "fopen");
 	}
 	tcgetattr(fileno(tty), &oldattr);


### PR DESCRIPTION
This avoids illegal seek errors when users send input while we're
outputting to the terminal.

Closes #42.