### PR TITLE
Fix undefined behavior in src/choices.c

### DIFF
--- a/src/choices.c
+++ b/src/choices.c
@@ -20,18 +20,21 @@ min_match_length(char *str, char *query)
 	size_t mstart;
 	size_t qpos;
 	size_t mpos;
+	int query_char;
 
 	for (mlen = 0, mstart = 0; str[mstart] != '\0'; ++mstart)
-		if (tolower(str[mstart]) == tolower(query[0])) {
-			for (qpos = 1, mpos = mstart + 1; query[qpos] != '\0'; ++qpos)
+		if (tolower((unsigned)str[mstart]) == tolower((unsigned)query[0])) {
+			for (qpos = 1, mpos = mstart + 1; query[qpos] != '\0'; ++qpos) {
+				query_char = tolower((unsigned)query[qpos]);
 				for (;; ++mpos) {
 					if (str[mpos] == '\0')
 						return mlen;
-					if (tolower(str[mpos]) == tolower(query[qpos])) {
+					if (tolower((unsigned)str[mpos]) == query_char) {
 						++mpos;
 						break;
 					}
 				}
+			}
 			if (mlen == 0 || mlen > mpos - mstart + 1)
 				mlen = mpos - mstart + 1;
 		}

--- a/src/choices.c
+++ b/src/choices.c
@@ -21,11 +21,13 @@ min_match_length(char *str, char *query)
 	size_t qpos;
 	size_t mpos;
 	int query_char;
+	int query_start;
 
+	query_start = tolower((unsigned char)query[0]);
 	for (mlen = 0, mstart = 0; str[mstart] != '\0'; ++mstart)
-		if (tolower((unsigned)str[mstart]) == tolower((unsigned)query[0])) {
+		if (tolower((unsigned char)str[mstart]) == query_start) {
 			for (qpos = 1, mpos = mstart + 1; query[qpos] != '\0'; ++qpos) {
-				query_char = tolower((unsigned)query[qpos]);
+				query_char = tolower((unsigned char)query[qpos]);
 				for (;; ++mpos) {
 					if (str[mpos] == '\0')
 						return mlen;


### PR DESCRIPTION
using libc shipped with cygwin,
 the build breaks with the following error message:

choices.c:25:3: error: array subscript has type 'char' [-Werror=char-subscripts]
   if (tolower(str[mstart]) == tolower(query[0])) {

Note: implementing tolower as a macro that does a lookup in
 an array - using the argument as an index - is a valid
 implementation according to the standard.

"the argument is an int, the value of which shall be representable as an
unsigned char or shall equal the value of the macro EOF.
If the argument has any other value, the behavior is undefined."