### PR TITLE
Feature/use query

### DIFF
--- a/man/man1/pick.1
+++ b/man/man1/pick.1
@@ -56,6 +56,8 @@ interface is operated with the following keys:
 Select between choices matching the current search query.
 .It Ic Enter
 Output the currently selected choice and exit.
+.It Ic Alt\&-Enter
+Output the current input query and exit.
 .It Ic "Printable characters"
 Printable characters are added to the search query input field and will refine
 the current search query.

--- a/src/tty.c
+++ b/src/tty.c
@@ -86,6 +86,10 @@ tty_getch()
 	if (ch == ESCAPE) {
 		ch = tty_getc();
 
+		if (ch == '\n') {
+			return TTY_ALT_ENTER;
+		}
+
 		if (ch == '[' || ch == 'O') {
 			ch = tty_getc();
 

--- a/src/tty.h
+++ b/src/tty.h
@@ -13,6 +13,7 @@
 #define TTY_CTRL_W 23
 #define TTY_DEL 127
 #define TTY_ENTER 10
+#define TTY_ALT_ENTER 266
 #define TTY_BACKSPACE 263
 #define TTY_UP 259
 #define TTY_DOWN 258

--- a/src/ui.c
+++ b/src/ui.c
@@ -74,6 +74,8 @@ ui_selected_choice(struct choices *choices, char *initial_query,
 				free(query);
 				return selected_choice(choices, selection);
 			}
+
+			break;
 		case TTY_ALT_ENTER:
 			tty_restore();
 			return choice_new(query, "", 1);

--- a/src/ui.c
+++ b/src/ui.c
@@ -74,6 +74,9 @@ ui_selected_choice(struct choices *choices, char *initial_query,
 				free(query);
 				return selected_choice(choices, selection);
 			}
+		case TTY_ALT_ENTER:
+			tty_restore();
+			return choice_new(query, "", 1);
 		case TTY_CTRL_N:
 			if (selection < visible_choices_count - 1) {
 				++selection;


### PR DESCRIPTION
/closes #58 

Using `Alt-Enter` in a terminal that outputs an escape prefix will use the user's input query directly.

This lets `pick` be used in situations where the user wishes to enter something not necessarily in the choice list.  For example:

```bash
git checkout $(git branch | cut -c 3- | pick)
```

With this change, users may checkout a `git` hash or tag, along with the original behavior of selecting a branch from a list.