### PR TITLE
Prefer `reallocarray` over `realloc`

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -29,6 +29,9 @@
    and to 0 otherwise. */
 #undef HAVE_REALLOC
 
+/* Define to 1 if you have the `reallocarray' function. */
+#undef HAVE_REALLOCARRAY
+
 /* Define to 1 if you have the `setlocale' function. */
 #undef HAVE_SETLOCALE
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([memmove setlocale strdup strlcpy strlcat])
+AC_CHECK_FUNCS([memmove reallocarray setlocale strdup strlcpy strlcat])
 AC_SEARCH_LIBS([initscr], [ncursesw ncurses], [], [
   AC_MSG_ERROR([unable to find initscr() function. Try to install ncurses])
 ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,4 +3,5 @@ AM_CFLAGS=-Wall -Wextra -pedantic-errors -Wno-unused-parameter -Werror
 bin_PROGRAMS=pick
 dist_pick_SOURCES=choice.c choice.h choices.c choices.h io.c io.h main.c \
 				  tty.c tty.h ui.c ui.h compat/queue.h compat/strlcpy.c \
-				  compat/strlcpy.h compat/strlcat.c compat/strlcat.h
+				  compat/strlcpy.h compat/strlcat.c compat/strlcat.h \
+				  compat/reallocarray.h compat/reallocarray.c

--- a/src/compat/reallocarray.c
+++ b/src/compat/reallocarray.c
@@ -1,0 +1,51 @@
+/*
+ * This file needs a "translation unit" - it needs anything for the compiler to
+ * compile. Since the point of this file is to not exist, declare an unused
+ * variable here.
+ */
+int unused;
+
+#include "config.h"
+
+#ifndef HAVE_REALLOCARRAY
+
+/*	$OpenBSD: reallocarray.c,v 1.2 2014/12/08 03:45:00 bcook Exp $	*/
+/*
+ * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
+
+void *
+reallocarray(void *optr, size_t nmemb, size_t size)
+{
+	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+	    nmemb > 0 && SIZE_MAX / nmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc(optr, size * nmemb);
+}
+
+#endif /* !HAVE_REALLOCARRAY */

--- a/src/compat/reallocarray.h
+++ b/src/compat/reallocarray.h
@@ -1,0 +1,14 @@
+/*
+ * This file needs a "translation unit" - it needs anything for the compiler to
+ * compile. Since the point of this file is to not exist, declare an unused
+ * variable here.
+ */
+int unused;
+
+#include "config.h"
+
+#ifndef HAVE_REALLOCARRAY
+
+void	*reallocarray(void *, size_t, size_t);
+
+#endif /* !HAVE_REALLOCARRAY */

--- a/src/ui.c
+++ b/src/ui.c
@@ -21,6 +21,10 @@
 #include "compat/strlcat.h"
 #endif /* !HAVE_STRLCAT */
 
+#ifndef HAVE_REALLOCARRAY
+#include "compat/reallocarray.h"
+#endif /* !HAVE_REALLOCARRAY */
+
 #include "choice.h"
 #include "choices.h"
 #include "ui.h"
@@ -225,9 +229,9 @@ ui_selected_choice(struct choices *choices, char *initial_query,
 		if (query_length == query_size - 1) {
 			query_size += query_size;
 
-			query = realloc(query, query_size * sizeof(char));
+			query = reallocarray(query, query_size, sizeof(char));
 			if (query == NULL) {
-				err(1, "realloc");
+				err(1, "reallocarray");
 			}
 		}
 
@@ -282,9 +286,9 @@ print_choices(struct choices *choices, int selection)
 		while (length > line_length) {
 			line_length = line_length * 2;
 
-			line = realloc(line, line_length);
+			line = reallocarray(line, line_length, sizeof(char));
 			if (line == NULL) {
-				err(1, "realloc");
+				err(1, "reallocarray");
 			}
 		}
 


### PR DESCRIPTION
When reallocating memory using `realloc`, passing in a number produced by a
multiplication operation, there is a risk of multiplication overflow:

    realloc(str, len * sizeof(char))`

These overflow issues can be avoided by using `reallocarray`.

`reallocarray` is implemented in the OpenBSD libc and has been added to
`compat/` for portability.

Closes #59.