### PR TITLE
Flush TTY when a full screen is drawn

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -164,6 +164,12 @@ tty_columns()
 	return columns;
 }
 
+int
+tty_flush()
+{
+	return fflush(tty_out);
+}
+
 static int
 tty_getc()
 {

--- a/src/tty.h
+++ b/src/tty.h
@@ -31,5 +31,6 @@ void tty_exit_standout_mode();
 void tty_move_cursor_to(int, int);
 int tty_lines();
 int tty_columns();
+int tty_flush();
 
 #endif /* TTY_H */

--- a/src/ui.c
+++ b/src/ui.c
@@ -71,6 +71,7 @@ ui_selected_choice(struct choices *choices, char *initial_query,
 	tty_show_cursor();
 
 	for (;;) {
+		tty_flush();
 		key = tty_getch();
 		switch(key) {
 		case TTY_ENTER:


### PR DESCRIPTION
The "pick" utility was not behaving well for me at all, and was unusable in both xterm and urxvt. I don't know why my tty is so different, but this fixes things for me.

Oddly enough the 1.1.1 release worked fine for me.