### PR TITLE
Fix a segfault when running pick -d on OS X

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -39,7 +39,7 @@ io_read_choices(int read_descriptions)
 
 	for (;;) {
 		line = NULL;
-		description = "";
+		description = NULL;
 		line_size = 0;
 
 		length = getline(&line, &line_size, stdin);
@@ -51,6 +51,10 @@ io_read_choices(int read_descriptions)
 
 		if (read_descriptions) {
 			strtok_r(line, field_separator, &description);
+		}
+
+		if (description == NULL) {
+			description = "";
 		}
 
 		choice = choice_new(line, description, 1);


### PR DESCRIPTION
Certain implementations of strtok_r set the context pointer to NULL when the delimiter is not found. This used to cause a segfault when trying to construct a choice with a NULL description.

## Additional details

I encountered a segfault when using pick installed via Homebrew on OS X 10.10.4. On my machine the bug can be easily reproduced by running any of the following commands:

```
$ pick -d <<< 'foo'
Segmentation fault: 11
$ pick -d <<< $'foo bar\n'
Segmentation fault: 11
```

I verified that this bug is not reproducible on Ubuntu when built with gcc version 4.8.4. The proposed fix was tested on OS X 10.10.4 and Ubuntu Linux 14.04.

### Crash dump:

```
Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000000

...

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_c.dylib             	0x00007fff857be152 strlen + 18
1   libsystem_c.dylib             	0x00007fff85817f79 strdup + 18
2   pick                          	0x00000001024447fa choice_new + 58
3   pick                          	0x0000000102444c5d io_read_choices + 206
4   pick                          	0x0000000102444df4 main + 244
5   libdyld.dylib                 	0x00007fff8d4cf5c9 start + 1
```

### GCC version details

**OS X 10.10.4**

```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 6.1.0 (clang-602.0.53) (based on LLVM 3.6.0svn)
Target: x86_64-apple-darwin14.4.0
Thread model: posix
```

**Ubuntu Server 14.04**

```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/4.8/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 4.8.4-2ubuntu1~14.04' --with-bugurl=file:///usr/share/doc/gcc-4.8/README.Bugs --enable-languages=c,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-4.8 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --with-gxx-include-dir=/usr/include/c++/4.8 --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --disable-libmudflap --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-4.8-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-4.8-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-4.8-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04)
```