### PR TITLE
Fix pick -d splitting behavior

### DIFF
--- a/man/man1/pick.1
+++ b/man/man1/pick.1
@@ -35,7 +35,7 @@ read and display descriptions.
 When the
 .Fl d
 option is supplied, input lines will be split into two parts by the last
-occurence of
+occurrence of
 .Ev IFS .
 Both parts will be displayed but only the first part will be used when
 searching.

--- a/src/io.c
+++ b/src/io.c
@@ -20,15 +20,15 @@ static char * eager_strpbrk(const char *, const char *);
 struct choices *
 io_read_choices(int read_descriptions)
 {
-	char *line, *description, *field_separator;
+	char *line, *description, *field_separators;
 	size_t line_size;
 	ssize_t length;
 	struct choice *choice;
 	struct choices *choices;
 
-	field_separator = getenv("IFS");
-	if (field_separator == NULL) {
-		field_separator = " ";
+	field_separators = getenv("IFS");
+	if (field_separators == NULL) {
+		field_separators = " ";
 	}
 
 	choices = malloc(sizeof(struct choices));
@@ -49,7 +49,7 @@ io_read_choices(int read_descriptions)
 
 		chomp(line, length);
 
-		if (read_descriptions && (description = eager_strpbrk(line, field_separator))) {
+		if (read_descriptions && (description = eager_strpbrk(line, field_separators))) {
 			*description++ = '\0';
 		} else {
 			description = "";

--- a/src/io.c
+++ b/src/io.c
@@ -15,6 +15,7 @@
 #include "choices.h"
 
 static void chomp(char *, ssize_t);
+static char * eager_strpbrk(const char *, const char *);
 
 struct choices *
 io_read_choices(int read_descriptions)
@@ -39,7 +40,6 @@ io_read_choices(int read_descriptions)
 
 	for (;;) {
 		line = NULL;
-		description = NULL;
 		line_size = 0;
 
 		length = getline(&line, &line_size, stdin);
@@ -49,11 +49,9 @@ io_read_choices(int read_descriptions)
 
 		chomp(line, length);
 
-		if (read_descriptions) {
-			strtok_r(line, field_separator, &description);
-		}
-
-		if (description == NULL) {
+		if (read_descriptions && (description = eager_strpbrk(line, field_separator))) {
+			*description++ = '\0';
+		} else {
 			description = "";
 		}
 
@@ -84,4 +82,15 @@ chomp(char *string, ssize_t length)
 	if (string[length - 1] == '\n') {
 		string[length - 1] = '\0';
 	}
+}
+
+static char *
+eager_strpbrk(const char *string, const char *separators) {
+	char *ptr = NULL, *tmp_ptr;
+	for (tmp_ptr = strpbrk(string, separators);
+	     tmp_ptr;
+	     tmp_ptr = strpbrk(tmp_ptr, separators)) {
+		ptr = tmp_ptr++;
+	}
+	return ptr;
 }


### PR DESCRIPTION
> When the -d option is supplied, input lines will be split into two parts by the last occurrence of IFS.

See #69 for more details. Replaced `strtok_r` with eager `strpbrk` to avoid unnecessary string mutations. Also fixed a typo in documentation. Tested on OS X 10.10.4.