### PR TITLE
README.md: fix incorrect filename; INSTALL.md.in: Add missing instruc…

### DIFF
--- a/INSTALL.md.in
+++ b/INSTALL.md.in
@@ -9,6 +9,7 @@ pick installation
 
 2. Configure the distribution.
 
+        ./autogen.sh
         ./configure
 
 3. Build and install pick:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ tar -xzf pick-VERSION.tar.gz
 
 ```sh
 cd pick-VERSION
-less INSTALL.md
+less INSTALL.md.in
 ```
 
 [the AUR]: https://aur.archlinux.org/packages/pick/


### PR DESCRIPTION
…tion

In README.md the filename of the INSTALL file containing instructions is
incorrect.  It should be INSTALL.md.in (Fixed in this commit)

In INSTALL.md.in there is a missing step.  You first should run
./autogen.sh to generate the configure file