### PR TITLE
Improve tty_putp error message

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,11 @@
 #define EX_SIG 128
 #define EX_SIGINT (EX_SIG + SIGINT)
 
+#define tty_putp(capability) do { \
+	if (tputs(capability, 1, tty_putc) == ERR) \
+		errx(1, #capability ": unknown terminfo capability"); \
+	} while (0)
+
 struct choice {
 	SLIST_ENTRY(choice)	 choices;
 	char			*description;
@@ -74,7 +79,6 @@ static size_t		 min_match_length(char *);
 static struct choice	*sort(struct choice *);
 static struct choice	*merge(struct choice *, struct choice *);
 static void		 init_tty(void);
-static void		 tty_putp(const char *);
 static int		 tty_putc(int);
 static void		 handle_sigint(int);
 static void		 restore_tty(void);
@@ -594,13 +598,6 @@ init_tty(void)
 	tty_putp(clear_screen);
 
 	signal(SIGINT, handle_sigint);
-}
-
-static void
-tty_putp(const char *string)
-{
-	if (tputs(string, 1, tty_putc) == ERR)
-		err(1, "tputs");
 }
 
 static int


### PR DESCRIPTION
When tty_putp fails the following message is outputted:
```
pick: tputs: Success
````
Since tputs does not set errno this message is confusing. Instead output
the name of the missing capability:
````
pick: enter_ca_mode: unknown terminfo capability
````
Notice that enter_ca_mode is just an example and will be substituted with
the capability that caused the failure during execution.

Discovered using pick with the Linux console.