### PR TITLE
Preserve order of input

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -203,7 +203,7 @@ get_choices(void)
 	if ((input.string = malloc(input.size)) == NULL)
 		err(1, "malloc");
 	for (;;) {
-		if ((length = read(0, input.string + input.length,
+		if ((length = read(STDIN_FILENO, input.string + input.length,
 				   input.size - input.length)) <= 0)
 		    break;
 

--- a/src/main.c
+++ b/src/main.c
@@ -105,8 +105,8 @@ static struct termios	 original_attributes;
 static struct choices	*choices;
 static struct {
 	size_t	size;
-	size_t	nmemb;
-	char	*v;
+	size_t	length;
+	char	*string;
 } input;
 
 int
@@ -200,28 +200,28 @@ get_choices(void)
 		field_separators = " ";
 
 	input.size = BUFSIZ;
-	if ((input.v = malloc(input.size)) == NULL)
+	if ((input.string = malloc(input.size)) == NULL)
 		err(1, "malloc");
 	for (;;) {
-		if ((length = read(0, input.v + input.nmemb,
-				   input.size - input.nmemb)) <= 0)
+		if ((length = read(0, input.string + input.length,
+				   input.size - input.length)) <= 0)
 		    break;
 
-		input.nmemb += length;
-		if (input.nmemb + 1 < input.size)
+		input.length += length;
+		if (input.length + 1 < input.size)
 			continue;
 		input.size *= 2;
-		if ((input.v = realloc(input.v, input.size)) == NULL)
+		if ((input.string = realloc(input.string, input.size)) == NULL)
 			err(1, "realloc");
 	}
-	memset(input.v + input.nmemb, '\0', input.size - input.nmemb);
+	memset(input.string + input.length, '\0', input.size - input.length);
 
 	if ((choices = malloc(sizeof(struct choices))) == NULL)
 		err(1, "malloc");
 
 	SLIST_INIT(choices);
 
-	start = input.v;
+	start = input.string;
 	while ((stop = strchr(start, '\n')) != NULL) {
 		*stop = '\0';
 
@@ -827,5 +827,5 @@ free_choices(void)
 	}
 
 	free(choices);
-	free(input.v);
+	free(input.string);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -68,7 +68,6 @@ SLIST_HEAD(choices, choice);
 __dead static void	 usage(void);
 __dead static void	 version(void);
 static void 		 get_choices(void);
-static void		 chomp(char *, ssize_t);
 static char		*eager_strpbrk(const char *, const char *);
 static struct choice	*new_choice(char *, char *, float);
 static void		 put_choice(struct choice *);
@@ -104,6 +103,11 @@ static int		 use_alternate_screen;
 static size_t		 query_size;
 static struct termios	 original_attributes;
 static struct choices	*choices;
+static struct {
+	size_t	size;
+	size_t	nmemb;
+	char	*v;
+} input;
 
 int
 main(int argc, char **argv)
@@ -188,48 +192,50 @@ version(void)
 void
 get_choices(void)
 {
-	char		*line, *description, *field_separators;
-	size_t		 line_size;
+	char		*description, *field_separators, *start, *stop;
 	ssize_t		 length;
 	struct choice	*choice;
 
 	if ((field_separators = getenv("IFS")) == NULL)
 		field_separators = " ";
 
+	input.size = BUFSIZ;
+	if ((input.v = malloc(input.size)) == NULL)
+		err(1, "malloc");
+	for (;;) {
+		if ((length = read(0, input.v + input.nmemb,
+				   input.size - input.nmemb)) <= 0)
+		    break;
+
+		input.nmemb += length;
+		if (input.nmemb + 1 < input.size)
+			continue;
+		input.size *= 2;
+		if ((input.v = realloc(input.v, input.size)) == NULL)
+			err(1, "realloc");
+	}
+	memset(input.v + input.nmemb, '\0', input.size - input.nmemb);
+
 	if ((choices = malloc(sizeof(struct choices))) == NULL)
 		err(1, "malloc");
 
 	SLIST_INIT(choices);
 
-	for (;;) {
-		line = NULL;
-		line_size = 0;
-
-		if ((length = getline(&line, &line_size, stdin)) == -1)
-			break;
-
-		chomp(line, length);
+	start = input.v;
+	while ((stop = strchr(start, '\n')) != NULL) {
+		*stop = '\0';
 
 		if (descriptions &&
-		    (description = eager_strpbrk(line, field_separators)))
+		    (description = eager_strpbrk(start, field_separators)))
 			*description++ = '\0';
 		else
 			description = "";
 
-		choice = new_choice(line, description, 1);
+		choice = new_choice(start, description, 1);
 		SLIST_INSERT_HEAD(choices, choice, choices);
 
-		free(line);
+		start = stop + 1;
 	}
-
-	free(line);
-}
-
-static void
-chomp(char *string, ssize_t length)
-{
-	if (string[length - 1] == '\n')
-		string[length - 1] = '\0';
 }
 
 static char *
@@ -252,8 +258,8 @@ new_choice(char *string, char *description, float score)
 	if ((choice = malloc(sizeof(struct choice))) == NULL)
 		err(1, "malloc");
 
-	choice->string = strdup(string);
-	choice->description = strdup(description);
+	choice->string = string;
+	choice->description = description;
 	choice->score = score;
 
 	return choice;
@@ -552,7 +558,7 @@ merge(struct choice *front, struct choice *back)
 	while (front != NULL && back != NULL) {
 		if (front->score > back->score ||
 		    (front->score == back->score &&
-		     strcmp(front->string, back->string) < 0)) {
+		     front->string < back->string)) {
 			choice->choices.sle_next = front;
 			choice = front;
 			front = front->choices.sle_next;
@@ -817,10 +823,9 @@ free_choices(void)
 		choice = SLIST_FIRST(choices);
 		SLIST_REMOVE_HEAD(choices, choices);
 
-		free(choice->string);
-		free(choice->description);
 		free(choice);
 	}
 
 	free(choices);
+	free(input.v);
 }


### PR DESCRIPTION
One annoying aspect of pick is that the order of input lines is not
preserved when the query is empty. By allocating the input in one
consecutive block of memory the fallback sorting method can be
simplified to comparing the address of the two choices corresponding
lines. The initial order of the input will then always be preserved
since &line[i] < &line[i + 1] holds true.

The input allocation and choice creation is done in two separate steps
in order to avoid the need to update any existing previous choice line
pointers if the input memory block gets reallocated and moved to another
region. In terms of theoretical time complexity it's still a linear
operation.

As a pleasant side-effect the number of necessary allocations has been
reduces since the choice string and description is no longer duplicated.