### PR TITLE
Fix Ctrl-K

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -344,7 +344,7 @@ selected_choice(void)
 			delete_between(
 			    query,
 			    query_length,
-			    cursor_position + 1,
+			    cursor_position,
 			    query_length);
 			query_length = cursor_position;
 			filter_choices();


### PR DESCRIPTION
Pressing Ctrl-K should (according to the man page) delete until the end
of the line. Previously, it would not delete the character under the
cursor and when pressed twice it would bring back the deleted characters
or segfault, depending on the system, due to a memory access error.

This commit fixes the memory access bug and brings the behavior in line
with Bash and Readline which both deletes the character under the
cursor.