### PR TITLE
Include <sys/ttydefaults.h> for the CTRL macro

### DIFF
--- a/src/pick.c
+++ b/src/pick.c
@@ -2,6 +2,7 @@
 #include "config.h"
 #endif
 
+#include <sys/ttydefaults.h>
 #include <ctype.h>
 #include <err.h>
 #include <limits.h>


### PR DESCRIPTION
With acd349122e36a49e17e3c04a54cfb08bea9e50fd the CTRL macro started
being used but <sys/ttydefaults.h> was never explicitly included, which
broke the build when using the Android NDK or the musl libc.