### PR TITLE
Add Unicode support

### DIFF
--- a/tests/09.in
+++ b/tests/09.in
@@ -1,0 +1,7 @@
+description: UTF-8
+input: ö\n
+output: ö
+
+å
+ä
+ö

--- a/tests/10.in
+++ b/tests/10.in
@@ -1,0 +1,7 @@
+description: UTF-8 backspace
+input: ö\b\n
+output: å
+
+å
+ä
+ö

--- a/tests/11.in
+++ b/tests/11.in
@@ -1,0 +1,6 @@
+description: UTF-8 false positive
+input: áá\n
+output: háh háh
+
+íš á
+háh háh

--- a/tests/12.in
+++ b/tests/12.in
@@ -1,0 +1,6 @@
+description: UTF-8 move backward and delete character under cursor
+input: aå^B^Da\n
+output: aa
+
+aa
+aå

--- a/tests/13.in
+++ b/tests/13.in
@@ -1,0 +1,6 @@
+description: UTF-8 delete word
+input: aa bå^Wbb\n
+output: aa bb
+
+aa bb
+aa bå

--- a/tests/14.in
+++ b/tests/14.in
@@ -1,0 +1,5 @@
+description: UTF-8 move backward and forward
+input: åaå^B^B^Bö\n
+output: öåaå
+
+öåaå

--- a/tests/15.in
+++ b/tests/15.in
@@ -1,0 +1,6 @@
+description: UTF-8 four byte wide characters
+input: 💩\n
+output: 💩
+
+😀
+💩

--- a/tests/16.in
+++ b/tests/16.in
@@ -1,0 +1,5 @@
+description: case insensitive
+input: a\n
+output: A
+
+A

--- a/tests/17.in
+++ b/tests/17.in
@@ -1,0 +1,5 @@
+description: non printable characters in query
+input: b\e[5~\e\n
+output: b
+
+a

--- a/tests/test.c
+++ b/tests/test.c
@@ -70,7 +70,7 @@ parseinput(const char *s)
 				return;
 			switch (*s) {
 			case 'b':
-				c = 0x7F;
+				c = 0x08;
 				break;
 			case 'e':
 				c = 0x1B;


### PR DESCRIPTION
Work in progress, would really appreciate some help with testing. A few notes in no particular order:

- The `get_key` function recognizes both `\033[` and `\033O`, which terminal omits the later?

- I changed `BACKSPACE` from `263` to `8` which is the decimal number for the backspace character. Is this a bad idea? Where did `263` come from?

- Comparing Unicode characters is not case insensitive. Using one of the wide character comparision functions seems to best way to do it at glance since it's not as trivial as comparing ASCII characters. Input on this would be appreciated.