### PR TITLE
Fix standout rendering of last line

### DIFF
--- a/src/pick.c
+++ b/src/pick.c
@@ -463,7 +463,6 @@ selected_choice(void)
 		tty_putp(cursor_invisible);
 
 		visible_choices_count = print_choices(selection);
-		tty_putp(clr_eos);
 		if (cursor_position >= scroll + columns)
 			scroll = cursor_position - columns + 1;
 		if (cursor_position < scroll)
@@ -673,6 +672,7 @@ print_choices(int selection)
 	size_t		 query_length;
 	struct choice	*choice;
 
+	tty_putp(clr_eos);
 	/* Emit query line. */
 	tty_putc('\n');
 


### PR DESCRIPTION
Emitting the `clr_eos` capability will clear all columns from the
current cursor position (inclusive) to the end of the screen. If the
last line was selected the last column would therefor also be cleared
including the standout. The solution is simply to clear the screen prior
redrawing the interface.