### PR TITLE
fix exit status of awk

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2,8 +2,8 @@
 
 field() {
   awk '
-  /^'$1':/ { sub(/^[^:]+: */, ""); print; exit 0 }
-  END { exit 1 }'
+  /^'$1':/ { sub(/^[^:]+: */, ""); print; found=1 }
+  END { exit !found }'
 }
 
 input() {


### PR DESCRIPTION
field() is always returning exit status 1, because END will be executed always, even after exit command inside body of awk.

ref: https://www.gnu.org/software/gawk/manual/html_node/Exit-Statement.html

According to above mentioned reference, exit in the END will use default success status, or use the exit status from the inner exit.
If  "exit:" is not defined in the test case then default EXIT_SUCCESS(0) is used and echo 0 will make the default exit code to 0.
If "exit:" is defined then exit 1 from the body will set the exit code to 1(EXIT_FAILURE) and same is used by the exit in END and the echo 0 will be skipped. 
Signed-off-by: Prahlad V <prahlad.eee@gmail.com>