### PR TITLE
Revert unintentional escape macro change

### DIFF
--- a/src/pick.c
+++ b/src/pick.c
@@ -35,12 +35,13 @@
 		errx(1, #capability ": unknown terminfo capability"); \
 	} while (0)
 
+#define ESCAPE 27
+
 enum {
 	UNKNOWN,
 	ALT_ENTER,
 	DEL,
 	ENTER,
-	ESCAPE,
 	CTRL_A,
 	CTRL_D,
 	CTRL_E,


### PR DESCRIPTION
Regression from e79f95b. ESCAPE is not a recognized key but instead used
in the `count_printable` function in order to recognize a escape
character.