### PR TITLE
Cleanup

### DIFF
--- a/src/pick.c
+++ b/src/pick.c
@@ -5,7 +5,6 @@
 #include <sys/ttydefaults.h>
 #include <ctype.h>
 #include <err.h>
-#include <limits.h>
 #include <locale.h>
 #include <signal.h>
 #include <stdio.h>

--- a/src/pick.c
+++ b/src/pick.c
@@ -330,7 +330,8 @@ selected_choice(void)
 		switch (key) {
 		case ENTER:
 			if (visible_choices_count > 0) {
-				if (selection >= 0 && selection < (ssize_t)choices.length)
+				if (selection >= 0
+				    && selection < (ssize_t)choices.length)
 					return &choices.v[selection];
 				else
 					return NULL;

--- a/src/pick.c
+++ b/src/pick.c
@@ -158,8 +158,8 @@ main(int argc, char **argv)
 	if (query == NULL) {
 		query_size = 64;
 
-		if ((query = calloc(query_size, sizeof(*query))) == NULL)
-			err(1, "calloc");
+		if ((query = calloc(query_size, sizeof(char))) == NULL)
+			err(1, NULL);
 	}
 
 	get_choices();
@@ -212,7 +212,7 @@ get_choices(void)
 
 	input.size = BUFSIZ;
 	if ((input.string = malloc(input.size)) == NULL)
-		err(1, "malloc");
+		err(1, NULL);
 	for (;;) {
 		if ((length = read(STDIN_FILENO, input.string + input.length,
 				   input.size - input.length)) <= 0)
@@ -223,13 +223,14 @@ get_choices(void)
 			continue;
 		input.size *= 2;
 		if ((input.string = realloc(input.string, input.size)) == NULL)
-			err(1, "realloc");
+			err(1, NULL);
 	}
 	memset(input.string + input.length, '\0', input.size - input.length);
 
 	choices.size = 16;
-	if ((choices.v = malloc(choices.size*sizeof(struct choice))) == NULL)
-		err(1, "malloc");
+	if ((choices.v = reallocarray(NULL, choices.size,
+			    sizeof(struct choice))) == NULL)
+		err(1, NULL);
 
 	start = input.string;
 	while ((stop = strchr(start, '\n')) != NULL) {
@@ -256,8 +257,9 @@ get_choices(void)
 		if (++choices.length + 1 < choices.size)
 			continue;
 		choices.size *= 2;
-		if ((choices.v = realloc(choices.v, choices.size*sizeof(struct choice))) == NULL)
-			err(1, "realloc");
+		if ((choices.v = reallocarray(choices.v, choices.size,
+				    sizeof(struct choice))) == NULL)
+			err(1, NULL);
 	}
 }
 

--- a/src/pick.c
+++ b/src/pick.c
@@ -112,7 +112,8 @@ static struct {
 int
 main(int argc, char **argv)
 {
-	int	option;
+	const struct choice	*choice;
+	int			 option;
 
 	use_alternate_screen = getenv("VIM") == NULL;
 
@@ -162,7 +163,11 @@ main(int argc, char **argv)
 	}
 
 	get_choices();
-	put_choice(selected_choice());
+	init_tty();
+	choice = selected_choice();
+	restore_tty();
+	if (choice != NULL)
+		put_choice(choice);
 
 	free(choices.v);
 	free(input.string);
@@ -308,7 +313,6 @@ selected_choice(void)
 	cursor_position = query_length = strlen(query);
 
 	filter_choices();
-	init_tty();
 
 	if (cursor_position >= (size_t)columns)
 		scroll = cursor_position - columns + 1;
@@ -327,7 +331,6 @@ selected_choice(void)
 		switch (key) {
 		case ENTER:
 			if (visible_choices_count > 0) {
-				restore_tty();
 				if (selection >= 0 && selection < (ssize_t)choices.length)
 					return &choices.v[selection];
 				else
@@ -336,7 +339,6 @@ selected_choice(void)
 
 			break;
 		case ALT_ENTER:
-			restore_tty();
 			choices.v[choices.length].string = query;
 			choices.v[choices.length].description = "";
 			return &choices.v[choices.length];

--- a/src/pick.c
+++ b/src/pick.c
@@ -584,9 +584,8 @@ init_tty(void)
 	struct termios	new_attributes;
 	int		i;
 
-	if ((tty_in = fopen("/dev/tty", "r")) == NULL) {
+	if ((tty_in = fopen("/dev/tty", "r")) == NULL)
 		err(1, "fopen");
-	}
 
 	tcgetattr(fileno(tty_in), &original_attributes);
 	new_attributes = original_attributes;

--- a/src/pick.c
+++ b/src/pick.c
@@ -157,7 +157,6 @@ main(int argc, char **argv)
 
 	if (query == NULL) {
 		query_size = 64;
-
 		if ((query = calloc(query_size, sizeof(char))) == NULL)
 			err(1, NULL);
 	}

--- a/src/pick.c
+++ b/src/pick.c
@@ -84,7 +84,6 @@ static int			 print_choices(int);
 static int			 get_key(char *, size_t, size_t *);
 static int			 tty_getc(void);
 static void			 delete_between(char *, size_t, size_t, size_t);
-static void			 free_choices(void);
 static void			 print_query(char *, size_t, size_t, size_t);
 static int			 choicecmp(const void *, const void *);
 static int			 isu8cont(unsigned char);
@@ -165,7 +164,8 @@ main(int argc, char **argv)
 	get_choices();
 	put_choice(selected_choice());
 
-	free_choices();
+	free(choices.v);
+	free(input.string);
 	free(query);
 
 	return EX_OK;
@@ -826,13 +826,6 @@ void
 delete_between(char *string, size_t length, size_t start, size_t end)
 {
 	memmove(string + start, string + end, length - end + 1);
-}
-
-void
-free_choices(void)
-{
-	free(choices.v);
-	free(input.string);
 }
 
 int

--- a/src/pick.c
+++ b/src/pick.c
@@ -150,9 +150,10 @@ main(int argc, char **argv)
 			usage();
 		}
 	}
-
 	argc -= optind;
 	argv += optind;
+	if (argc > 0)
+		usage();
 
 	if (query == NULL) {
 		query_size = 64;

--- a/src/pick.c
+++ b/src/pick.c
@@ -276,8 +276,8 @@ eager_strpbrk(const char *string, const char *separators)
 size_t
 count_printable(char *str, size_t length)
 {
-	int	in_esc_seq = 0, printable = 0;
 	size_t	i;
+	int	in_esc_seq = 0, printable = 0;
 
 	for (i = 0; i < length; i++) {
 		if (in_esc_seq) {
@@ -304,10 +304,10 @@ put_choice(const struct choice *choice)
 const struct choice *
 selected_choice(void)
 {
-	char		 buf[6];
-	int		 key, selection = 0, visible_choices_count;
-	int		 word_position;
-	size_t		 cursor_position, length, query_length, scroll;
+	size_t		cursor_position, length, query_length, scroll;
+	char		buf[6];
+	int		key, selection = 0, visible_choices_count;
+	int		word_position;
 
 	cursor_position = query_length = strlen(query);
 
@@ -523,7 +523,7 @@ score(struct choice *choice)
 int
 min_match(const char *string, size_t offset, size_t *start, size_t *end)
 {
-	char	 *s, *e, *q;
+	char	*s, *e, *q;
 
 	q = query;
 	if ((s = e = strcasechr(&string[offset], q)) == NULL)
@@ -580,8 +580,8 @@ strcasechr(const char *s1, const char *s2)
 void
 init_tty(void)
 {
-	struct termios	 new_attributes;
-	int		 i;
+	struct termios	new_attributes;
+	int		i;
 
 	if ((tty_in = fopen("/dev/tty", "r")) == NULL) {
 		err(1, "fopen");
@@ -671,9 +671,9 @@ print_query(char *string, size_t length, size_t position, size_t scroll)
 int
 print_choices(int selection)
 {
-	int		 col, i, j, k;
-	size_t		 query_length;
 	struct choice	*choice;
+	size_t		 query_length;
+	int		 col, i, j, k;
 
 	tty_putp(clr_eos);
 	/* Emit query line. */

--- a/src/pick.c
+++ b/src/pick.c
@@ -461,8 +461,6 @@ selected_choice(void)
 			query[query_length] = '\0';
 			filter_choices();
 			selection = 0;
-
-			break;
 		}
 
 		tty_putp(cursor_invisible);

--- a/src/pick.c
+++ b/src/pick.c
@@ -179,9 +179,7 @@ main(int argc, char **argv)
 __dead void
 usage(void)
 {
-	extern char	*__progname;
-
-	fprintf(stderr, "usage: %s [-hvS] [-d [-o]] [-x | -X] [-q query]\n"
+	fprintf(stderr, "usage: pick [-hvS] [-d [-o]] [-x | -X] [-q query]\n"
 	    "    -h          output this help message and exit\n"
 	    "    -v          output the version and exit\n"
 	    "    -S          disable sorting\n"
@@ -189,7 +187,7 @@ usage(void)
 	    "    -o          output description of selected on exit\n"
 	    "    -x          enable alternate screen\n"
 	    "    -X          disable alternate screen\n"
-	    "    -q query    supply an initial search query\n", __progname);
+	    "    -q query    supply an initial search query\n");
 
 	exit(EX_USAGE);
 }

--- a/src/pick.c
+++ b/src/pick.c
@@ -655,16 +655,16 @@ put_line(char *string, int length)
 }
 
 void
-print_query(char *query, size_t length, size_t position, size_t scroll)
+print_query(char *string, size_t length, size_t position, size_t scroll)
 {
 	size_t	i = 0;
 
 	tty_putp(restore_cursor);
-	put_line(query + scroll, length - scroll);
+	put_line(string + scroll, length - scroll);
 
 	tty_putp(restore_cursor);
 	while (i < position - scroll) {
-		while (isu8cont(query[++i]));
+		while (isu8cont(string[++i]));
 		tty_putp(cursor_right);
 	}
 }
@@ -767,7 +767,7 @@ get_key(char *buf, size_t size, size_t *nread)
 		{ { "\033O3~" },		4,	DEL },
 		{ { NULL },			0,	0 },
 	};
-	const char	*input;
+	const char	*key;
 	int		 i;
 
 	*nread = 0;
@@ -775,8 +775,8 @@ getc:
 	buf[(*nread)++] = tty_getc();
 	size--;
 	for (i = 0; keys[i].input.s; i++) {
-		input = keys[i].length > 1 ? keys[i].input.s : &keys[i].input.c;
-		if (*nread > keys[i].length || strncmp(buf, input, *nread))
+		key = keys[i].length > 1 ? keys[i].input.s : &keys[i].input.c;
+		if (*nread > keys[i].length || strncmp(buf, key, *nread))
 			continue;
 
 		if (*nread == keys[i].length)

--- a/tests/19.in
+++ b/tests/19.in
@@ -1,0 +1,6 @@
+description: bogus arguments
+arguments: a
+input: \n
+exit: 1
+
+a

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -25,10 +25,10 @@ main() {
   DIR=$(dirname "$0")
   PATH="${DIR}/../src:${PATH}"
 
-  in=$(mktemp pick.XXXXXX)
-  exp=$(mktemp pick.XXXXXX)
-  act=$(mktemp pick.XXXXXX)
-  err=$(mktemp pick.XXXXXX)
+  in=$(mktemp -t pick.XXXXXX)
+  exp=$(mktemp -t pick.XXXXXX)
+  act=$(mktemp -t pick.XXXXXX)
+  err=$(mktemp -t pick.XXXXXX)
   trap 'rm "$in" "$exp" "$act" "$err"' EXIT
 
   [ $# -eq 0 ] && set $(find "$DIR" -name '*.in')


### PR DESCRIPTION
Time for another round of cleanups. The commits should hopefully be
self-explanatory. Other than that, here's two things that I would like to see
happening:

- Since both `choices` and `input` are data-structures that live through-out
  the whole execution of pick I would rather omit the free-ing and let the OS
  handle it instead. This is a common pattern among other BSD-commands.

- I find the following line in the `main` function confusing:

  ```c
  use_alternate_screen = getenv("VIM") == NULL;
  ```

  It should not the alternate screen if executed inside Vim(?). Wouldn't be
  better if the pick.vim plugin explicitly made of the `-X` option? If not:
  a comment would be useful since the behavior seems very specific.
