### PR TITLE
Remove altscreen condition if invoked from Vim

### DIFF
--- a/man/man1/pick.1
+++ b/man/man1/pick.1
@@ -88,17 +88,6 @@ The following environment variables will affect the execution of
 .Bl -tag -width IFS
 .It Ev IFS
 Determines the separator used between choices and descriptions.
-.It Ev VIM
-If set, disables the use of the alternate screen terminal feature. This avoids
-issues with using the alternate screen when run using
-.Fn system
-in
-.Xr vim 1 .
-To force the use of the alternate screen run
-.Nm
-with the
-.Fl x
-option.
 .El
 .Sh EXAMPLES
 .Nm

--- a/src/pick.c
+++ b/src/pick.c
@@ -93,7 +93,7 @@ static FILE		*tty_out;
 static char		*query;
 static int		 descriptions;
 static int		 output_description;
-static int		 use_alternate_screen;
+static int		 use_alternate_screen = 1;
 static int		 sort = 1;
 static size_t		 query_size;
 static struct termios	 original_attributes;

--- a/src/pick.c
+++ b/src/pick.c
@@ -119,8 +119,6 @@ main(int argc, char **argv)
 		err(1, "pledge");
 #endif
 
-	use_alternate_screen = getenv("VIM") == NULL;
-
 	setlocale(LC_CTYPE, "");
 
 	while ((option = getopt(argc, argv, "dhoq:SvxX")) != -1) {


### PR DESCRIPTION
The pick.vim plugin now makes explicit use of the `-X' option. As
discussed in #120.