### PR TITLE
Reduce flickering

### DIFF
--- a/src/pick.c
+++ b/src/pick.c
@@ -476,6 +476,10 @@ selected_choice(void)
 		tty_putp(cursor_invisible);
 
 		visible_choices_count = print_choices(selection);
+		if (visible_choices_count < lines - 1) {
+			tty_putc('\n');
+			tty_putp(clr_eos);
+		}
 		if (cursor_position >= scroll + columns)
 			scroll = cursor_position - columns + 1;
 		if (cursor_position < scroll)
@@ -684,7 +688,6 @@ print_choices(int selection)
 	size_t		 query_length;
 	int		 col, i, j, k;
 
-	tty_putp(clr_eos);
 	/* Emit query line. */
 	tty_putc('\n');
 


### PR DESCRIPTION
The clearing of the screen introduced in 72239f0 made the screen flicker
for users in tmux. Possibly because tmux might take longer time to draw
than terminal emulators.

Instead of clearing the whole screen before printing the choices and
query, clear from the line below the last choice to the end of the
screen before printing the query. This only can and needs to be done if
the visible choices and the query do not completely fill the screen.

This might resolve #131.