### PR TITLE
Update Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ apt-get install pick
 ### Mac OS X via Homebrew
 
 ```sh
-brew tap thoughtbot/formulae
 brew install pick
 ```
 


### PR DESCRIPTION
Since Pick was added to Homebrew core in Homebrew/homebrew-core#1977,
adding the thoughtbot tap before installing with `brew` is no longer
needed.