### PR TITLE
Improve search performance by not wasting cycles

### DIFF
--- a/src/pick.c
+++ b/src/pick.c
@@ -481,7 +481,7 @@ filter_choices(void)
 {
 	struct pollfd	pfd;
 	size_t		i;
-	int		ready;
+	int		nready;
 
 	for (i = 0; i < choices.length; i++) {
 		score(&choices.v[i]);
@@ -495,9 +495,9 @@ filter_choices(void)
 		if (i % 50 == 0) {
 			pfd.fd = fileno(tty_in);
 			pfd.events = POLLIN;
-			if ((ready = poll(&pfd, 1, 0)) == -1)
+			if ((nready = poll(&pfd, 1, 0)) == -1)
 				err(1, "poll");
-			else if (ready == 1 && pfd.revents & (POLLIN | POLLHUP))
+			if (nready == 1 && pfd.revents & (POLLIN | POLLHUP))
 				break;
 		}
 	}


### PR DESCRIPTION
Using pick with a large number of choices is slow. The threshold on my
computer is somewhere around 10k lines of input. Benchmarking the
filtering revealed that the scoring is the bottleneck. This is no
surprise since the current search algorithm is an `O(n^2)` operation in
worst case. The second most time consuming task is the sorting of the
choices. However, the time taken for `qsort(3)` is consistent and several
order of magnitude less time consuming than the scoring.

When the user inputs a query longer greater than 1 character we
currently waste lots of cycles by performing a search every time a new
character is received. Even if the current query is outdated since the
user already has typed more character yet to be processed. Therefore,
abort the search if there is unprocessed user input available. This is
done by performing a non-blocking `poll(2)` call on the user input file
descriptor. The check for new input is done on every 50:th iteration.
The number is empirically chosen and close to the number of lines in my
terminal. There's no guarantee that this number is optimal for everyone.
Experimenting with the number of different computers is therefore of
interest.

This change gives the notion of a responsive interface even when the
input is large. Running the following command prior and after this
change should result in a noticeable speed-up:

```sh
$ find ~ | pick
```

I think this a decent trade-off in terms of gained performance vs.
complexity.

Tested on OpenBSD and Ubuntu. However, it's currently **not working on OS
X** since `pfd.revents & POLLNVAL`[1] is always true. Any help to resolve
this issue would be much appreciated. 

[1] The corresponding file descriptor is invalid