### PR TITLE
Improve test code coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,8 @@ TESTS=tests/01.t tests/02.t tests/03.t tests/04.t tests/05.t tests/06.t \
       tests/13.t tests/14.t tests/15.t tests/16.t tests/17.t tests/18.t \
       tests/19.t tests/20.t tests/21.t tests/22.t tests/23.t tests/24.t \
       tests/25.t tests/26.t tests/27.t tests/28.t tests/29.t tests/30.t \
-      tests/31.t tests/32.t tests/33.t tests/34.t tests/35.t
+      tests/31.t tests/32.t tests/33.t tests/34.t tests/35.t tests/36.t \
+      tests/37.t tests/38.t tests/39.t tests/40.t tests/41.t tests/42.t
 TEST_EXTENSIONS=.t
 T_LOG_COMPILER=sh tests/test.sh
 check_PROGRAMS=tests/pick-test

--- a/tests/36.t
+++ b/tests/36.t
@@ -1,0 +1,7 @@
+description: delete til cursor
+keys: abc \002 \025 \\n
+stdin:
+abc
+c
+stdout:
+c

--- a/tests/37.t
+++ b/tests/37.t
@@ -1,0 +1,7 @@
+description: delete til end of line
+keys: ab \002 \013 \\n
+stdin:
+a
+ab
+stdout:
+a

--- a/tests/38.t
+++ b/tests/38.t
@@ -1,0 +1,7 @@
+description: delete words
+keys: \027 ab\\ cd \027 \027 \\n
+stdin:
+ab
+ab cd
+stdout:
+ab

--- a/tests/39.t
+++ b/tests/39.t
@@ -1,0 +1,6 @@
+description: move cursor to beginning and end of line
+keys: b \001 a \005 c \\n
+stdin:
+abc
+stdout:
+abc

--- a/tests/40.t
+++ b/tests/40.t
@@ -1,0 +1,6 @@
+description: ignore unrecognized terminal capability
+keys: \033[1~ \\n
+stdin:
+a
+stdout:
+a

--- a/tests/41.t
+++ b/tests/41.t
@@ -1,0 +1,7 @@
+description: query realloc
+args: -q a
+keys: bc \\n
+stdin:
+abc
+stdout:
+abc

--- a/tests/42.t
+++ b/tests/42.t
@@ -1,0 +1,6 @@
+description: tabs in input
+keys: \\n
+stdin:
+	a
+stdout:
+	a

--- a/tests/README.md
+++ b/tests/README.md
@@ -60,8 +60,8 @@ Exit code of the pick process, defaults to `0` if omitted.
 
 Sequence of characters sent as keyboard input to the pick process. The value
 will be sent through `printf(1)` prior sending it to the pick process. Spaces
-will be stripped, if not escaped using `\`. A newline character must expressed
-as `\\n`.
+will be stripped, if not escaped. A backslash character is expressed as `\\`,
+thus newline equals `\\n` and space `\\ `.
 
 - stdin
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -7,9 +7,9 @@ usage() {
 
 fail=
 
-stdout=$(mktemp -t pick.XXXXXX)
+stdout=$(mktemp -t pick.act.XXXXXX)
 stdin=$(mktemp -t pick.XXXXXX)
-out=$(mktemp -t pick.XXXXXX)
+out=$(mktemp -t pick.exp.XXXXXX)
 trap "rm "$stdout" "$stdin" "$out"" EXIT
 
 for testcase; do
@@ -34,7 +34,7 @@ for testcase; do
     cat "$out" 1>&2
     fail=1
   fi
-  if [ -s "$stdout" ] && ! diff -c "$stdout" "$out"; then
+  if [ -s "$stdout" ] && ! diff -u "$out" "$stdout"; then
     fail=1
   fi
 done


### PR DESCRIPTION
Using `gcov(1)` revealed a couple of code paths not covered by the
tests. Some of the uncovered behavior can't be verified using the
current test framework but a potential crash can still be detected.