### PR TITLE
Discard unrecognized escape sequences

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,8 @@ TESTS=tests/01.t tests/02.t tests/03.t tests/04.t tests/05.t tests/06.t \
       tests/19.t tests/20.t tests/21.t tests/22.t tests/23.t tests/24.t \
       tests/25.t tests/26.t tests/27.t tests/28.t tests/29.t tests/30.t \
       tests/31.t tests/32.t tests/33.t tests/34.t tests/35.t tests/36.t \
-      tests/37.t tests/38.t tests/39.t tests/40.t tests/41.t tests/42.t
+      tests/37.t tests/38.t tests/39.t tests/40.t tests/41.t tests/42.t \
+      tests/43.t
 TEST_EXTENSIONS=.t
 T_LOG_COMPILER=sh tests/test.sh
 check_PROGRAMS=tests/pick-test

--- a/tests/43.t
+++ b/tests/43.t
@@ -1,0 +1,6 @@
+description: unrecgonized long escape sequence
+keys: \033[1111111111111111~ \\n
+stdin:
+a
+stdout:
+a


### PR DESCRIPTION
If the user inputs a unrecognized escape sequence longer than the size
of the input buffer, parts of the sequence would end up in the query.

Since the sequence should be ignored, there's no need to put the read
bytes in the input buffer.