### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,138 @@
+# v1.4.0 - 2016-06-03
+
+## New features
+
+- Add a test suite (Anton Lindqvist, prahlad, Score_Under)
+
+- Add an `-S` option for disable sorting of choices (Calle Erlandsson)
+
+- Add UTF-8 support (Anton Lindqvist)
+
+- Add support for using the delete key and Ctrl-D interchangeably (prahlad)
+
+- Make use of `pledge(1)` on OpenBSD (Anton Lindqvist)
+
+## Bug fixes
+
+- Fix compatibility issues with the Android NDK and the musl libc (Fredrik
+  Fornwall)
+
+- Fix issues with newlines caused by colored input (Calle Erlandsson)
+
+- Fix standout rendering of the last line (Anton Lindqvist)
+
+- Refactoring and cleanup (Anton Lindqvist)
+
+## Removed features
+
+- Remove altscreen condition if invoked from Vim (Anton Lindqvist)
+
+# v1.3.0 - 2016-02-12
+
+## New features
+
+- Highlight the matched substring of choices (Anton Lindqvist)
+
+- Scroll query horizontally as needed (Calle Erlandsson)
+
+## Bug fixes
+
+- Add Debian/Ubuntu installation instructions to the README (Scott Stevenson)
+
+- Improve error messages for missing terminfo capabilities (Anton Lindqvist)
+
+- Don't clear the screen unless using the alternate screen (Anton Lindqvist)
+
+- When the query is empty, preserve the input order of choices (Anton Lindqvist)
+
+- Performance improvements and implementation simplifications (Anton Lindqvist)
+
+- Correct Ctrl-K behavior (Calle Erlandsson)
+
+# v1.2.1 - 2015-10-16
+
+## Bug fixes
+
+- Prevent flickering on some ttys by explicitly flushing output after drawing a
+  full screen (Score_Under)
+
+- Prevent segfaults on systems where `strtok_r` sets the context pointer to
+  `NULL` when the delimiter is not found (Artem Chistyakov)
+
+- Make the `-d` option behave as it is documented (Artem Chistyakov)
+
+- Prevent scrolling (Calle Erlandsson)
+
+# v1.2.0 - 2015-08-07
+
+## New features
+
+- Allow users to pick the current input query. (Ross Hadden)
+
+- Add installation instructions for Mac OS X via MacPorts. (Chunyang Xu)
+
+- Sort choices with the same score lexicographically making sort order
+  deterministic. (Calle Erlandsson)
+
+## Bug fixes
+
+- Improve error handling. (Calle Erlandsson)
+
+- Don't drop user input under high load. (Calle Erlandsson)
+
+- Fix build failures on systems where `ncurses` does not exists but `ncursesw`
+  does. (Aggelos Avgerinos)
+
+- Fix build failures on Cygwin. (Gabor Buella)
+
+# v1.1.1 - 2015-03-09
+
+## Bug fixes
+
+- Fix checksum issues in Homebrew formula and AUR PKGBUILD. (Calle Erlandsson)
+
+- Avoid "Illegal seek" errors when processing many choices. (Calle Erlandsson)
+
+# v1.1.0 - 2015-02-27
+
+## New features
+
+- Automatically disable alternate screen in Vim. (Calle Erlandsson)
+
+- Add the `-x` option to enable alternate screen. (Calle Erlandsson)
+
+- Add Homebrew formula. (Teo Ljungberg)
+
+- Add AUR PKGBUILD. (Calle Erlandsson)
+
+- Improve README (Matt Jankowski, Calle Erlandsson)
+
+## Bug fixes
+
+- Add missing options to usage message. (Calle Erlandsson)
+
+# v1.0.0 - 2015-02-26
+
+## New features
+
+- Emacs key bindings. (Keith Smiley, Calle Erlandsson)
+
+- Descriptions support. (Calle Erlandsson)
+
+## Bug fixes
+
+- Handle SIGINT (Keith Smiley)
+
+- Fix build issues on certain platforms (Ruben Laguna, Keith Smiley, Calle
+  Erlandsson)
+
+- Fix issues related to Vim `system()` and usage of the alternate screen (Keith
+  Smiley, Calle Erlandsson)
+
+# v0.0.1 - 2014-08-18
+
+## New features
+
+- Fuzzy select anything. (Calle Erlandsson, Mike Burns)
+
+- Man page. (Calle Erlandsson)


### PR DESCRIPTION
The diff between the previous release `v1.4.0` and `master` is quite
massive. In order to make the release process less tedious I propose
keeping a changelog up-to-date during development. The changelog can
then used as a boilerplate for the release notes.

We're missing out on some context related to the changes by not
referencing the corresponding PR. When adding future entries to the
changelog, the PR should be mentioned.

`CHANGELOG.md` was generated using the following script, with some
Vim post-processing:

```sh
body() {
	awk '
	/markdown-body/ { body = 1; next }
	body == 1 && /<\/div/ { exit 0 }
	body == 1 && length > 0 { sub(/^ +/, ""); print }
	'
}

htmltomd() {
	local tag=$1 sub=$2

	sed "s|<${tag}>\([^<]*\)</${tag}>|${sub}|g"
}

exec 1>CHANGELOG.md

git tag -l --format='%(contents:subject) %(taggerdate:short)' | sort -r | while read tag date; do
	printf '# %s - %s\n\n' "$tag" "$date"

	ftp -o - "https://github.com/thoughtbot/pick/releases/tag/${tag}" \
		| body \
		| sed 's|</*ul>||' \
		| htmltomd h1 '## \1' \
		| htmltomd code '`\1`' \
		| htmltomd li '- \1'
done
```