### PR TITLE
Make `make distcheck` pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,6 @@ stamp-h1
 .dirstamp
 test-driver
 test-suite.log
-tests/test
-tests/test.sh.log
-tests/test.sh.trs
+tests/pick-test
+tests/*.log
+tests/*.trs

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,9 +16,9 @@ TESTS=tests/01.t tests/02.t tests/03.t tests/04.t tests/05.t tests/06.t \
       tests/37.t tests/38.t tests/39.t tests/40.t tests/41.t tests/42.t \
       tests/43.t
 TEST_EXTENSIONS=.t
-T_LOG_COMPILER=sh tests/test.sh
+T_LOG_COMPILER=sh $(top_srcdir)/tests/test.sh
 check_PROGRAMS=tests/pick-test
-tests_pick_test_SOURCES=tests/pick-test.c
+tests_pick_test_SOURCES=$(TESTS) tests/test.sh tests/pick-test.c
 # Required by posix_openpt on Linux.
 tests_pick_test_CFLAGS=-D_XOPEN_SOURCE=600
 

--- a/tests/pick-test.c
+++ b/tests/pick-test.c
@@ -1,11 +1,11 @@
 #include <sys/ioctl.h>
-#include <sys/limits.h>
 #include <sys/select.h>
 #include <sys/wait.h>
 
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Preparing for release, I ran `make distcheck` and found it failing. With the changes in this PR it is passing.

@mptre, I'd love your feedback on the changes and also if you could try running it on your system.